### PR TITLE
Source as unnamed param

### DIFF
--- a/src/cli-parser/builder.js
+++ b/src/cli-parser/builder.js
@@ -2,7 +2,6 @@ module.exports = (yargs) => yargs
   .usage('$0 -s <source folder> -t <target folder> -n <output name> -p <plugin modules>')
   .option('s', {
     alias: 'source',
-    demand: true,
     requiresArg: true,
     describe: 'Source folder to be processed, can be a relative or an absolute path.',
     type: 'string',

--- a/src/cli-parser/handler.js
+++ b/src/cli-parser/handler.js
@@ -14,6 +14,7 @@ const closeProcess = (code) => {
 
 module.exports = (argv) => {
   const {
+    _ = [],
     source,
     target,
     name,
@@ -38,7 +39,14 @@ module.exports = (argv) => {
     options.plugins = []
   }
 
-  return compileCss(source, options)
+  const srcFolder = !source && _.length > 1 && _[1] ? _[1] : source
+
+  if (!srcFolder) {
+    error(`Error Compiling css Modules, a source folder must be defined!`)
+    return closeProcess(1)
+  }
+
+  return compileCss(srcFolder, options)
     .then(() => {
       debug(`Css modules compiled! ${emoji.get(':punch:')}`)
       closeProcess(0)

--- a/test/cli-parser/handler.spec.js
+++ b/test/cli-parser/handler.spec.js
@@ -18,10 +18,16 @@ handler.__Rewire__('debug', debug)
 
 describe('CLI parser', () => {
   describe('handler', () => {
+    beforeEach(() => {
+      compiler.reset()
+      error.reset()
+      getPluginsFail.reset()
+      getPluginsSuccess.reset()
+      getPluginsEmpty.reset()
+    })
+
     it('should parse parameters and apply defaults where required', () => {
       handler.__Rewire__('getPlugins', getPluginsEmpty)
-      getPluginsEmpty.reset()
-      compiler.reset()
 
       const argv = {
         source: './src',
@@ -40,7 +46,6 @@ describe('CLI parser', () => {
     })
 
     it('should use first non-hypenated option as source folder if no --source is defined', () => {
-      compiler.reset()
       let argv = {
         source: './src',
         _: ['compile', './src-folder', 'some', 'other', 'option'],
@@ -59,8 +64,6 @@ describe('CLI parser', () => {
     })
 
     it('should exit logging an error if no source is given', () => {
-      compiler.reset()
-      error.reset()
       handler({})
       assert.equal(compiler.counter, 0)
       assert.equal(error.counter, 1)
@@ -72,8 +75,6 @@ describe('CLI parser', () => {
 
     it('should use passed blacklist', () => {
       handler.__Rewire__('getPlugins', getPluginsEmpty)
-      getPluginsEmpty.reset()
-      compiler.reset()
 
       const argv = {
         source: './src',
@@ -89,9 +90,6 @@ describe('CLI parser', () => {
 
     it('should throws if `get-plugin` return an error string', () => {
       handler.__Rewire__('getPlugins', getPluginsFail)
-      getPluginsFail.reset()
-      compiler.reset()
-      error.reset()
 
       const argv = {
         plugins: ['a', 'b'],
@@ -105,8 +103,6 @@ describe('CLI parser', () => {
 
     it('should pass the loaded plugins list to the compiler', () => {
       handler.__Rewire__('getPlugins', getPluginsSuccess)
-      getPluginsSuccess.reset()
-      compiler.reset()
 
       const argv = {
         source: './src',
@@ -116,7 +112,7 @@ describe('CLI parser', () => {
       }
       handler(argv)
 
-      assert.equal(getPluginsFail.counter, 1)
+      assert.equal(getPluginsSuccess.counter, 1)
       assert.equal(compiler.counter, 1)
       assert.ok(Array.isArray(compiler.lastArgs[1].plugins))
       assert.equal(compiler.lastArgs[1].plugins.length, 2)

--- a/test/cli-parser/handler.spec.js
+++ b/test/cli-parser/handler.spec.js
@@ -39,6 +39,37 @@ describe('CLI parser', () => {
       assert.equal(compiler.lastArgs[1].plugins.length, 0)
     })
 
+    it('should use first non-hypenated option as source folder if no --source is defined', () => {
+      compiler.reset()
+      let argv = {
+        source: './src',
+        _: ['compile', './src-folder', 'some', 'other', 'option'],
+      }
+      handler(argv)
+      assert.equal(compiler.counter, 1)
+      assert.equal(compiler.lastArgs[0], argv.source)
+
+      compiler.reset()
+      argv = {
+        _: ['compile', './src-folder', 'some', 'other', 'option'],
+      }
+      handler(argv)
+      assert.equal(compiler.counter, 1)
+      assert.equal(compiler.lastArgs[0], argv._[1])
+    })
+
+    it('should exit logging an error if no source is given', () => {
+      compiler.reset()
+      error.reset()
+      handler({})
+      assert.equal(compiler.counter, 0)
+      assert.equal(error.counter, 1)
+      assert.equal(
+        error.lastArgs[0],
+        'Error Compiling css Modules, a source folder must be defined!'
+      )
+    })
+
     it('should use passed blacklist', () => {
       handler.__Rewire__('getPlugins', getPluginsEmpty)
       getPluginsEmpty.reset()


### PR DESCRIPTION
This closes #25 adding support for `source` as non-hypenated option
